### PR TITLE
Define ejsonkms package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.16-alpine
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/envato/ejsonkms
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.16-alpine
-ENV GO111MODULE=on
 WORKDIR /go/src/github.com/envato/ejsonkms
 COPY . .
 RUN apk add git gcc musl-dev

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NAME=ejsonkms
+PACKAGE=github.com/envato/ejsonkms
 VERSION=$(shell cat VERSION)
 GOFILES=$(shell find . -type f -name '*.go')
 
@@ -12,17 +13,20 @@ build/bin/linux-amd64: $(GOFILES)
 	mkdir -p "$(@D)"
 	GOOS=linux GOARCH=amd64 go build \
 	-ldflags '-s -w -X main.version="$(VERSION)"' \
-	-o "$@"
+	-o "$@" \
+	"$(PACKAGE)/cmd/$(NAME)"
 
 build/bin/darwin-amd64: $(GOFILES)
 	GOOS=darwin GOARCH=amd64 go build \
 	-ldflags '-s -w -X main.version="$(VERSION)"' \
-	-o "$@"
+	-o "$@" \
+	"$(PACKAGE)/cmd/$(NAME)"
 
 build/bin/darwin-arm64: $(GOFILES)
 	GOOS=darwin GOARCH=arm64 go build \
 	-ldflags '-s -w -X main.version="$(VERSION)"' \
-	-o "$@"
+	-o "$@" \
+	"$(PACKAGE)/cmd/$(NAME)"
 
 clean:
 	rm -rf build

--- a/actions.go
+++ b/actions.go
@@ -1,4 +1,4 @@
-package main
+package ejsonkms
 
 import (
 	"encoding/json"
@@ -9,7 +9,7 @@ import (
 	"github.com/Shopify/ejson2env"
 )
 
-func encryptAction(args []string) error {
+func EncryptAction(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("at least one file path must be given")
 	}
@@ -23,7 +23,7 @@ func encryptAction(args []string) error {
 	return nil
 }
 
-func decryptAction(args []string, awsRegion, outFile string) error {
+func DecryptAction(args []string, awsRegion, outFile string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("exactly one file path must be given")
 	}
@@ -53,7 +53,7 @@ type ejsonKmsFile struct {
 	PrivateKeyEnc string `json:"_private_key_enc"`
 }
 
-func keygenAction(args []string, kmsKeyID, awsRegion, outFile string) error {
+func KeygenAction(args []string, kmsKeyID, awsRegion, outFile string) error {
 	ejsonKmsKeys, err := Keygen(kmsKeyID, awsRegion)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func keygenAction(args []string, kmsKeyID, awsRegion, outFile string) error {
 	return nil
 }
 
-func envAction(ejsonFilePath, awsRegion string, quiet bool) error {
+func EnvAction(ejsonFilePath, awsRegion string, quiet bool) error {
 	exportFunc := ejson2env.ExportEnv
 	if quiet {
 		exportFunc = ejson2env.ExportQuiet

--- a/actions_test.go
+++ b/actions_test.go
@@ -1,4 +1,4 @@
-package main
+package ejsonkms
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 func TestEnv(t *testing.T) {
 	Convey("Env", t, func() {
 		out := capturer.CaptureOutput(func() {
-			err := envAction("testdata/test.ejson", "us-east-1", false)
+			err := EnvAction("testdata/test.ejson", "us-east-1", false)
 			So(err, ShouldBeNil)
 		})
 
@@ -20,7 +20,7 @@ func TestEnv(t *testing.T) {
 	})
 
 	Convey("Env with no private key", t, func() {
-		err := envAction("testdata/test_no_private_key.ejson", "us-east-1", false)
+		err := EnvAction("testdata/test_no_private_key.ejson", "us-east-1", false)
 
 		Convey("should fail", func() {
 			So(err, ShouldNotBeNil)

--- a/cmd/ejsonkms/main.go
+++ b/cmd/ejsonkms/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/envato/ejsonkms"
 	"github.com/urfave/cli"
 )
 
@@ -27,7 +28,7 @@ func main() {
 			Name:  "encrypt",
 			Usage: "(re-)encrypt one or more EJSON files",
 			Action: func(c *cli.Context) {
-				if err := encryptAction(c.Args()); err != nil {
+				if err := ejsonkms.EncryptAction(c.Args()); err != nil {
 					fmt.Fprintln(os.Stderr, "Encryption failed:", err)
 					os.Exit(1)
 				}
@@ -47,7 +48,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) {
-				if err := decryptAction(c.Args(), c.String("aws-region"), c.String("o")); err != nil {
+				if err := ejsonkms.DecryptAction(c.Args(), c.String("aws-region"), c.String("o")); err != nil {
 					fmt.Fprintln(os.Stderr, "Decryption failed:", err)
 					os.Exit(1)
 				}
@@ -71,7 +72,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) {
-				if err := keygenAction(c.Args(), c.String("kms-key-id"), c.String("aws-region"), c.String("o")); err != nil {
+				if err := ejsonkms.KeygenAction(c.Args(), c.String("kms-key-id"), c.String("aws-region"), c.String("o")); err != nil {
 					fmt.Fprintln(os.Stderr, "Key generation failed:", err)
 					os.Exit(1)
 				}
@@ -104,7 +105,7 @@ func main() {
 					fail(fmt.Errorf("no secrets.ejson filename passed"))
 				}
 
-				if err := envAction(filename, awsRegion, quiet); nil != err {
+				if err := ejsonkms.EnvAction(filename, awsRegion, quiet); nil != err {
 					fail(err)
 				}
 			},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       KMS_REGION: us-east-1
       KMS_ACCOUNT_ID: 111122223333
     volumes:
-      - "./local_kms/seed.yaml:/init/seed.yaml"
+      - "./local_kms/:/init/"
     expose:
       - 8080
   tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: "nsmithuk/local-kms"
     environment:
       REGION: us-east-1
+      KMS_REGION: us-east-1
+      KMS_ACCOUNT_ID: 111122223333
     volumes:
       - "./local_kms/seed.yaml:/init/seed.yaml"
     expose:
@@ -16,6 +18,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: '123'
       AWS_SECRET_ACCESS_KEY: xyz
+      AWS_REGION: us-east-1
       FAKE_AWSKMS_URL: http://awskms:8080
     links:
       - awskms

--- a/ejsonkms.go
+++ b/ejsonkms.go
@@ -1,4 +1,4 @@
-package main
+package ejsonkms
 
 import (
 	"encoding/json"

--- a/ejsonkms_test.go
+++ b/ejsonkms_test.go
@@ -1,4 +1,4 @@
-package main
+package ejsonkms
 
 import (
 	"testing"

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -42,6 +43,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/kms.go
+++ b/kms.go
@@ -1,4 +1,4 @@
-package main
+package ejsonkms
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
- Moves the CLI code to cmd/ejsonkms so that the core part of the code can be used as a package from other go programs.
- Fixes some issues with the local-kms setup
- Updates golang version used in tests

<details><summary>go test</summary>

```
❯ docker-compose run tests sh
Creating ejsonkms_tests_run ... done
/go/src/github.com/envato/ejsonkms # go test
go: downloading github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d
go: downloading github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
go: downloading github.com/jtolds/gls v4.20.0+incompatible
go: downloading github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
.
2 total assertions

..
4 total assertions

.....
9 total assertions

..
11 total assertions

..
13 total assertions

PASS
ok      github.com/envato/ejsonkms      0.031s
```

</details>