### PR TITLE
Add pre-commit-hook to run ejsonkms encrypt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,5 @@
+# Defines supported pre-commit hooks for this project. 
+
 - id: run-ejsonkms-encrypt
   name: run-ejsonkms-encrypt
   description: Run ejsonkms encrypt on all ejson files in your repository.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: run-ejsonkms-encrypt
+  name: run-ejsonkms-encrypt
+  description: Run ejsonkms encrypt on all ejson files in your repository.
+  entry: ejsonkms encrypt
+  language: golang
+  types: [file]
+  files: '\.ejson$'

--- a/README.md
+++ b/README.md
@@ -62,3 +62,16 @@ secret123
 ```
 
 Note that only secrets under the "environment" key will be exported using the `env` command.
+
+## pre-commit hook
+
+A [pre-commit](https://pre-commit.com/) hook is also supported to automatically run `ejsonkms encrypt` on all `.ejson` files in a repository.
+
+To use, add the following to a `.pre-commit-conifg.yaml` file in your repository:
+
+```yaml
+repos:
+  - repo: https://github.com/envato/ejsonkms
+    hooks:
+      - id: run-ejsonkms-encrypt
+```


### PR DESCRIPTION
Add `.pre-commit-hooks.yaml` configuration with a hook `run-ejsonkms-encrypt` to run `ejsonkms encrypt` on all `.ejson` files in a repository