### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Precompiled binaries can be downloaded from [releases](https://github.com/envato
 ### Go
 
 ```
-go get -u github.com/envato/ejsonkms
+go install github.com/envato/ejsonkms@latest
 ```
 
 This will install the binary to `$GOBIN/ejsonkms`.


### PR DESCRIPTION
Update go installation instructions, since 'go get' is no longer supported outside a module:


```sh
➜  cdk git:(oliver/app-to-shuttle) go get -u github.com/envato/ejsonkms
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

➜  cdk git:(oliver/app-to-shuttle) go install github.com/envato/ejsonkms@latest 
go: downloading github.com/envato/ejsonkms v0.2.0
go: downloading github.com/aws/aws-sdk-go v1.23.12
go: downloading github.com/Shopify/ejson v1.2.1
go: downloading github.com/Shopify/ejson2env v2.0.0+incompatible
go: downloading github.com/urfave/cli v1.20.0
go: downloading github.com/taskcluster/shell v0.0.0-20161108133149-4039a2cd6f88
go: downloading github.com/dustin/gojson v0.0.0-20130803055424-057ac0edc14e
go: downloading golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
➜  cdk git:(oliver/app-to-shuttle) 
```