### PR TITLE
Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Precompiled binaries can be downloaded from [releases](https://github.com/envato
 ### Go
 
 ```
-go install github.com/envato/ejsonkms@latest
+go install github.com/envato/ejsonkms/cmd/ejsonkms@latest
 
 # Move binary to somewhere on $PATH. E.g.,
 sudo cp "${GOBIN:-$HOME/go/bin}/ejsonkms" /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that only secrets under the "environment" key will be exported using the `e
 
 A [pre-commit](https://pre-commit.com/) hook is also supported to automatically run `ejsonkms encrypt` on all `.ejson` files in a repository.
 
-To use, add the following to a `.pre-commit-conifg.yaml` file in your repository:
+To use, add the following to a `.pre-commit-config.yaml` file in your repository:
 
 ```yaml
 repos:


### PR DESCRIPTION
## Context

I've encountered an issue while installing `ejsonkms`.

The error message: `package github.com/envato/ejsonkms is not a main package`

### Why this happens?

`github.com/envato/ejsonkms`: This refers to the root of the repository.

 If the root package does not contain a main package (i.e., a main.go file with a main function), Go cannot build an executable from it.
 
**Result**: This command fails with the error package github.com/envato/ejsonkms is not a main package because it points to a package that is not intended to be compiled into an executable.


## Changes

- Update installation code
- Fix typo