### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
           - '*'
     commit-message:
       prefix: Dependabot
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: Dependabot


### PR DESCRIPTION
## Context

Dependabot keeps Go module dependencies up to date but does not track the versions of the GitHub Actions used in the project's workflows.

## Changes

Add a `github-actions` ecosystem block to `.github/dependabot.yml`, mirroring the existing `gomod` config: monthly schedule, a single group covering all actions, and the `Dependabot` commit-message prefix.

## Considerations

Dependabot will open PRs to bump action versions referenced in `.github/workflows/*.yml`.